### PR TITLE
feat: HTTP file parsing and client refactor

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -17,3 +17,7 @@ Last Updated: 2025-05-27
 | TASK-013 | Create `testdata/http_request_files/post_with_json_body.http`             | Done     | AI       | 2025-06-02 |
 | TASK-014 | Add test case to `http_file_parser_test.go` for `post_with_json_body.http`| Done     | AI       | 2025-06-02 |
 | TASK-015 | Extend parsing logic for POST requests and JSON bodies                      | Done     | AI       | 2025-06-03 |
+| TASK-017 | Make `ExecuteRequest` unexported and update call sites                      | Done        | AI       | 2025-05-28 |
+| TASK-018 | Add `context.Context` parameter to `ExecuteFile` and `executeRequest`       | Done        | AI       | 2025-05-28 |
+| TASK-019 | Refactor `client_test.go` to base all tests on `.http` files via `ExecuteFile`| Done        | AI       | 2025-05-29 |
+| TASK-020 | Remove direct unit tests for (now unexported) `executeRequest`              | Done        | AI       | 2025-05-29 |

--- a/testdata/http_request_files/get_with_override_header.http
+++ b/testdata/http_request_files/get_with_override_header.http
@@ -1,0 +1,3 @@
+GET /somepath
+X-Override: file-value
+X-File-Only: present 

--- a/testdata/http_request_files/invalid_method.http
+++ b/testdata/http_request_files/invalid_method.http
@@ -1,0 +1,1 @@
+INVALIDMETHOD /test 

--- a/testdata/http_request_files/relative_path_get.http
+++ b/testdata/http_request_files/relative_path_get.http
@@ -1,0 +1,1 @@
+GET todos/1 


### PR DESCRIPTION
Implements parsing of .http files (REQ-LIB-001) with comprehensive unit tests using real .http files (TASK-001 to TASK-007, TASK-009 to TASK-011, TASK-013 to TASK-015).\n\nRefactors the client:\n- ExecuteRequest is now unexported (executeRequest).\n- ExecuteFile and executeRequest now accept context.Context.\n- client_test.go refactored to use ExecuteFile with .http files for all scenarios, removing direct tests for the unexported executeRequest.\n- Added client tests for WithBaseURL, WithDefaultHeaders, and invalid method errors using .http files.\n(TASK-017, TASK-018, TASK-019, TASK-020).\n\nAlso reflects the decision to remove E2E testing infrastructure and updates relevant guidelines and tasks accordingly.